### PR TITLE
feat: disable slide gesture around confirm slider button

### DIFF
--- a/app/graphql/generated.gql
+++ b/app/graphql/generated.gql
@@ -860,6 +860,7 @@ query StatefulNotifications($after: String) {
         deepLink
         createdAt
         acknowledgedAt
+        addToBulletin
         __typename
       }
       pageInfo {

--- a/app/graphql/generated.ts
+++ b/app/graphql/generated.ts
@@ -1062,6 +1062,7 @@ export type Mutation = {
   readonly quizClaim: QuizClaimPayload;
   readonly statefulNotificationAcknowledge: StatefulNotificationAcknowledgePayload;
   readonly supportChatMessageAdd: SupportChatMessageAddPayload;
+  readonly supportChatReset: SuccessPayload;
   /** @deprecated will be moved to AccountContact */
   readonly userContactUpdateAlias: UserContactUpdateAliasPayload;
   readonly userEmailDelete: UserEmailDeletePayload;
@@ -1814,6 +1815,7 @@ export type SettlementViaOnChain = {
 export type StatefulNotification = {
   readonly __typename: 'StatefulNotification';
   readonly acknowledgedAt?: Maybe<Scalars['Timestamp']['output']>;
+  readonly addToBulletin: Scalars['Boolean']['output'];
   readonly body: Scalars['String']['output'];
   readonly createdAt: Scalars['Timestamp']['output'];
   readonly deepLink?: Maybe<Scalars['String']['output']>;
@@ -8825,6 +8827,7 @@ export type MutationResolvers<ContextType = any, ParentType extends ResolversPar
   quizClaim?: Resolver<ResolversTypes['QuizClaimPayload'], ParentType, ContextType, RequireFields<MutationQuizClaimArgs, 'input'>>;
   statefulNotificationAcknowledge?: Resolver<ResolversTypes['StatefulNotificationAcknowledgePayload'], ParentType, ContextType, RequireFields<MutationStatefulNotificationAcknowledgeArgs, 'input'>>;
   supportChatMessageAdd?: Resolver<ResolversTypes['SupportChatMessageAddPayload'], ParentType, ContextType, RequireFields<MutationSupportChatMessageAddArgs, 'input'>>;
+  supportChatReset?: Resolver<ResolversTypes['SuccessPayload'], ParentType, ContextType>;
   userContactUpdateAlias?: Resolver<ResolversTypes['UserContactUpdateAliasPayload'], ParentType, ContextType, RequireFields<MutationUserContactUpdateAliasArgs, 'input'>>;
   userEmailDelete?: Resolver<ResolversTypes['UserEmailDeletePayload'], ParentType, ContextType>;
   userEmailRegistrationInitiate?: Resolver<ResolversTypes['UserEmailRegistrationInitiatePayload'], ParentType, ContextType, RequireFields<MutationUserEmailRegistrationInitiateArgs, 'input'>>;
@@ -9120,6 +9123,7 @@ export interface SignedDisplayMajorAmountScalarConfig extends GraphQLScalarTypeC
 
 export type StatefulNotificationResolvers<ContextType = any, ParentType extends ResolversParentTypes['StatefulNotification'] = ResolversParentTypes['StatefulNotification']> = {
   acknowledgedAt?: Resolver<Maybe<ResolversTypes['Timestamp']>, ParentType, ContextType>;
+  addToBulletin?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   body?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   createdAt?: Resolver<ResolversTypes['Timestamp'], ParentType, ContextType>;
   deepLink?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;

--- a/app/graphql/generated.ts
+++ b/app/graphql/generated.ts
@@ -2623,7 +2623,7 @@ export type StatefulNotificationsQueryVariables = Exact<{
 }>;
 
 
-export type StatefulNotificationsQuery = { readonly __typename: 'Query', readonly me?: { readonly __typename: 'User', readonly statefulNotifications: { readonly __typename: 'StatefulNotificationConnection', readonly nodes: ReadonlyArray<{ readonly __typename: 'StatefulNotification', readonly id: string, readonly title: string, readonly body: string, readonly deepLink?: string | null, readonly createdAt: number, readonly acknowledgedAt?: number | null }>, readonly pageInfo: { readonly __typename: 'PageInfo', readonly endCursor?: string | null, readonly hasNextPage: boolean, readonly hasPreviousPage: boolean, readonly startCursor?: string | null } } } | null };
+export type StatefulNotificationsQuery = { readonly __typename: 'Query', readonly me?: { readonly __typename: 'User', readonly statefulNotifications: { readonly __typename: 'StatefulNotificationConnection', readonly nodes: ReadonlyArray<{ readonly __typename: 'StatefulNotification', readonly id: string, readonly title: string, readonly body: string, readonly deepLink?: string | null, readonly createdAt: number, readonly acknowledgedAt?: number | null, readonly addToBulletin: boolean }>, readonly pageInfo: { readonly __typename: 'PageInfo', readonly endCursor?: string | null, readonly hasNextPage: boolean, readonly hasPreviousPage: boolean, readonly startCursor?: string | null } } } | null };
 
 export type StatefulNotificationAcknowledgeMutationVariables = Exact<{
   input: StatefulNotificationAcknowledgeInput;
@@ -4823,6 +4823,7 @@ export const StatefulNotificationsDocument = gql`
         deepLink
         createdAt
         acknowledgedAt
+        addToBulletin
       }
       pageInfo {
         endCursor

--- a/app/screens/notification-history-screen/notification-history-screen.tsx
+++ b/app/screens/notification-history-screen/notification-history-screen.tsx
@@ -20,6 +20,7 @@ gql`
           deepLink
           createdAt
           acknowledgedAt
+          addToBulletin
         }
         pageInfo {
           endCursor

--- a/app/screens/send-bitcoin-screen/send-bitcoin-confirmation-screen.tsx
+++ b/app/screens/send-bitcoin-screen/send-bitcoin-confirmation-screen.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react"
 import { ActivityIndicator, TouchableOpacity, View } from "react-native"
+import { PanGestureHandler } from "react-native-gesture-handler"
 import ReactNativeHapticFeedback from "react-native-haptic-feedback"
 
 import { gql } from "@apollo/client"
@@ -422,13 +423,18 @@ const SendBitcoinConfirmationScreen: React.FC<Props> = ({ route }) => {
           </View>
         ) : null}
         <View style={styles.buttonContainer}>
-          <GaloySliderButton
-            isLoading={sendPaymentLoading}
-            initialText={LL.SendBitcoinConfirmationScreen.slideToConfirm()}
-            loadingText={LL.SendBitcoinConfirmationScreen.slideConfirming()}
-            onSwipe={handleSendPayment}
-            disabled={!validAmount || hasAttemptedSend}
-          />
+          {/* disable slide gestures in area around the slider button */}
+          <PanGestureHandler>
+            <View style={styles.sliderContainer}>
+              <GaloySliderButton
+                isLoading={sendPaymentLoading}
+                initialText={LL.SendBitcoinConfirmationScreen.slideToConfirm()}
+                loadingText={LL.SendBitcoinConfirmationScreen.slideConfirming()}
+                onSwipe={handleSendPayment}
+                disabled={!validAmount || hasAttemptedSend}
+              />
+            </View>
+          </PanGestureHandler>
         </View>
       </View>
     </Screen>
@@ -442,6 +448,7 @@ const useStyles = makeStyles(({ colors }) => ({
     flex: 1,
   },
   fieldContainer: {
+    paddingHorizontal: 20,
     marginBottom: 12,
   },
   noteText: {
@@ -537,7 +544,7 @@ const useStyles = makeStyles(({ colors }) => ({
     alignItems: "center",
   },
   screenStyle: {
-    padding: 20,
+    paddingTop: 20,
     flexGrow: 1,
   },
   iconContainer: {
@@ -559,5 +566,8 @@ const useStyles = makeStyles(({ colors }) => ({
     flexDirection: "row",
     justifyContent: "space-between",
     alignItems: "center",
+  },
+  sliderContainer: {
+    padding: 20,
   },
 }))


### PR DESCRIPTION
Fixes #3081 

Added a `PanGestureHandler` which captures slide gestures in areas surrounding the confirm slider button. This prevents the native navigation handler from catching this event, and back action is not triggered.

**Demo:**

https://github.com/GaloyMoney/blink-mobile/assets/17739006/91ae2854-9160-4dcf-b6a2-879e176cba15



