### PR TITLE
feat: Add backspace long press functionality to currency keyboard

### DIFF
--- a/app/components/currency-keyboard/currency-keyboard.tsx
+++ b/app/components/currency-keyboard/currency-keyboard.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import React, { useEffect, useState } from "react"
 import { Pressable, StyleProp, View, ViewStyle } from "react-native"
 
 import { testProps } from "@app/utils/testProps"
@@ -96,11 +96,39 @@ const Key = ({
     return baseStyle
   }
 
+  const [timerId, setTimerId] = useState<NodeJS.Timeout | null>(null)
+
+  const handleBackSpacePressIn = (numberPadKey: KeyType) => {
+    const id = setInterval(() => {
+      if (numberPadKey === KeyType.Backspace) {
+        handleKeyPress(numberPadKey)
+      }
+    }, 300)
+    setTimerId(id)
+  }
+
+  const handleBackSpacePressOut = () => {
+    if (timerId) {
+      clearInterval(timerId)
+      setTimerId(null)
+    }
+  }
+
+  useEffect(() => {
+    return () => {
+      if (timerId) {
+        clearInterval(timerId)
+      }
+    }
+  }, [timerId])
+
   return (
     <Pressable
       style={pressableStyle}
       hitSlop={20}
+      onPressIn={() => handleBackSpacePressIn(numberPadKey)}
       onPress={() => handleKeyPress(numberPadKey)}
+      onPressOut={handleBackSpacePressOut}
       {...testProps(`Key ${numberPadKey}`)}
     >
       {({ pressed }) => {


### PR DESCRIPTION
Fixes #3244 

Long press backspace to continuously delete numbers

[Screencast from 25-05-24 04:42:31 PM IST.webm](https://github.com/GaloyMoney/blink-mobile/assets/17739006/3f5cbbc5-3fb8-4d5b-bf28-c0f902674923)
