### PR TITLE
chore: update waiting for code time

### DIFF
--- a/app/screens/phone-auth-screen/phone-login-validation.tsx
+++ b/app/screens/phone-auth-screen/phone-login-validation.tsx
@@ -199,7 +199,8 @@ export const PhoneLoginValidationScreen: React.FC<PhoneLoginValidationScreenProp
   const isUpgradeFlow = currentLevel === AccountLevel.Zero
 
   const [code, _setCode] = useState("")
-  const [secondsRemaining, setSecondsRemaining] = useState<number>(30)
+  // Wait 2.5 minutes before allowing another code request
+  const [secondsRemaining, setSecondsRemaining] = useState<number>(150)
   const { phone, channel } = route.params
   const {
     theme: { colors },

--- a/app/screens/phone-auth-screen/phone-registration-validation.tsx
+++ b/app/screens/phone-auth-screen/phone-registration-validation.tsx
@@ -172,7 +172,8 @@ export const PhoneRegistrationValidateScreen: React.FC<
   const [phoneValidate] = useUserPhoneRegistrationValidateMutation()
 
   const [code, _setCode] = useState("")
-  const [secondsRemaining, setSecondsRemaining] = useState<number>(30)
+  // Wait 2.5 minutes before allowing another code request
+  const [secondsRemaining, setSecondsRemaining] = useState<number>(150)
   const { phone, channel } = route.params
 
   const {


### PR DESCRIPTION
Almost all users request the phone code between 2 and 4 times (with the data after the last backend updat...e this can be the main reason to message cost). This PR updates waiting time from 30 to 150 secs (2.5 mins)

https://ui.honeycomb.io/galoy/datasets/galoy-bbw/result/bre758WPtdS

