### PR TITLE
fix: always show full address for pos and static qr in settings

### DIFF
--- a/app/screens/settings-screen/settings/account-pos.tsx
+++ b/app/screens/settings-screen/settings/account-pos.tsx
@@ -10,7 +10,6 @@ import { SettingsRow } from "../row"
 export const AccountPOS: React.FC = () => {
   const { appConfig } = useAppConfig()
   const posUrl = appConfig.galoyInstance.posUrl
-  const shortUrl = appConfig.galoyInstance.lnAddressHostname
 
   const { LL } = useI18nContext()
 
@@ -18,13 +17,12 @@ export const AccountPOS: React.FC = () => {
   if (!data?.me?.username) return <></>
 
   const pos = `${posUrl}/${data.me.username}`
-  const short = `${shortUrl}/${data.me.username}`
 
   return (
     <SettingsRow
       loading={loading}
       title={LL.SettingsScreen.pos()}
-      subtitle={short}
+      subtitle={pos}
       subtitleShorter={data.me.username.length > 22}
       leftIcon="calculator"
       rightIcon={<GaloyIcon name="link" size={24} />}

--- a/app/screens/settings-screen/settings/account-static-qr.tsx
+++ b/app/screens/settings-screen/settings/account-static-qr.tsx
@@ -10,7 +10,6 @@ import { SettingsRow } from "../row"
 export const AccountStaticQR: React.FC = () => {
   const { appConfig } = useAppConfig()
   const posUrl = appConfig.galoyInstance.posUrl
-  const shortUrl = appConfig.galoyInstance.lnAddressHostname
 
   const { LL } = useI18nContext()
 
@@ -18,13 +17,12 @@ export const AccountStaticQR: React.FC = () => {
   if (!data?.me?.username) return <></>
 
   const qrUrl = `${posUrl}/${data.me.username}/print`
-  const short = `${shortUrl}/${data.me.username}/print`
 
   return (
     <SettingsRow
       loading={loading}
       title={LL.SettingsScreen.staticQr()}
-      subtitle={short}
+      subtitle={qrUrl}
       subtitleShorter={true}
       leftIcon="qr-code-outline"
       rightIcon={<GaloyIcon name="link" size={24} />}


### PR DESCRIPTION
Fixing the issue where the `LnAdressHostname` is displayed in place of the `posUrl`

The correct address for the Pos and StaticQR should  start with `pay.blink.sv`:

![IMG_20241205_150326](https://github.com/user-attachments/assets/c6d0b643-d7a4-45ec-84ed-25146ee55264)
