### PR TITLE
fix: kvstore identifier

### DIFF
--- a/ios/GaloyApp/GaloyApp.entitlements
+++ b/ios/GaloyApp/GaloyApp.entitlements
@@ -18,6 +18,6 @@
 		<string>NDEF</string>
 	</array>
 	<key>com.apple.developer.ubiquity-kvstore-identifier</key>
-	<string>$(TeamIdentifierPrefix)$(CFBundleIdentifier)</string>
+	<string>AYPCPV46WW.$(CFBundleIdentifier)</string>
 </dict>
 </plist>

--- a/ios/GaloyApp/GaloyAppDebug.entitlements
+++ b/ios/GaloyApp/GaloyAppDebug.entitlements
@@ -18,6 +18,6 @@
 	    <string>NDEF</string>
 	</array>
 	<key>com.apple.developer.ubiquity-kvstore-identifier</key>
-	<string>$(TeamIdentifierPrefix)$(CFBundleIdentifier)</string>
+	<string>AYPCPV46WW.$(CFBundleIdentifier)</string>
 </dict>
 </plist>


### PR DESCRIPTION
use old team id to avoid provisioning profile issues