### PR TITLE
chore: remove keychain-access-groups

### DIFF
--- a/ios/GaloyApp/GaloyApp.entitlements
+++ b/ios/GaloyApp/GaloyApp.entitlements
@@ -19,10 +19,5 @@
 	</array>
 	<key>com.apple.developer.ubiquity-kvstore-identifier</key>
 	<string>AYPCPV46WW.$(CFBundleIdentifier)</string>
-	<key>keychain-access-groups</key>
-	<array>
-		<string>UL7ND37VAD.$(CFBundleIdentifier)</string>
-		<string>AYPCPV46WW.$(CFBundleIdentifier)</string>
-	</array>
 </dict>
 </plist>

--- a/ios/GaloyApp/GaloyAppDebug.entitlements
+++ b/ios/GaloyApp/GaloyAppDebug.entitlements
@@ -19,10 +19,5 @@
 	</array>
 	<key>com.apple.developer.ubiquity-kvstore-identifier</key>
 	<string>AYPCPV46WW.$(CFBundleIdentifier)</string>
-	<key>keychain-access-groups</key>
-	<array>
-		<string>UL7ND37VAD.$(CFBundleIdentifier)</string>
-		<string>AYPCPV46WW.$(CFBundleIdentifier)</string>
-	</array>
 </dict>
 </plist>


### PR DESCRIPTION
rollback when build is successful